### PR TITLE
Correctly zero ttl in Varnish 4.

### DIFF
--- a/src/tests/11-really-purged.vtc
+++ b/src/tests/11-really-purged.vtc
@@ -67,6 +67,8 @@ client c1 {
 	expect resp.status == 200
 	expect resp.http.x-via == "hit"
 
+	delay 2
+
 	# run the softpurge
 	txreq -req "PURGE" -url "/"
 	rxresp
@@ -77,6 +79,7 @@ client c1 {
 	expect resp.http.x-via == "hit"
 	expect resp.status == 200
 	expect resp.http.x-object-hits != 0
+	expect resp.http.x-object-ttl <= 0
 
 	# check that the obj was refreshed via a bgfetch in prev req
 	txreq -url "/"

--- a/src/vmod_softpurge.c
+++ b/src/vmod_softpurge.c
@@ -84,7 +84,7 @@ vmod_softpurge(const struct vrt_ctx *ctx)
 
 		// Update the object's TTL so that it expires right now.
 		if (o->exp.ttl > (now - o->exp.t_origin))
-			EXP_Rearm(o, now, now - o->exp.t_origin, o->exp.grace, o->exp.keep);
+			EXP_Rearm(o, now, 0, o->exp.grace, o->exp.keep);
 
 		VSL(SLT_Debug, 0, "XX: object updated. ttl ends in %.3f, grace ends in %.3f for object %i",
 		    (EXP_Ttl(ctx->req, o) - now),


### PR DESCRIPTION
I found that `EXP_Rearm` expects exact ttl in Varnish 4.
